### PR TITLE
Update UBN validator for compatibility with new format

### DIFF
--- a/lib/taiwan_validator/ubn_validator.rb
+++ b/lib/taiwan_validator/ubn_validator.rb
@@ -13,7 +13,7 @@ class TaiwanValidator::UbnValidator < ActiveModel::EachValidator
         digit
       end.inject(&:+)
 
-      results % 10 == 0 || (ubn[6] == "7" && (results + 1) % 10 == 0)
+      results % 5 == 0 || (ubn[6] == "7" && (results + 1) % 5 == 0)
     end
 
     private

--- a/spec/ubn_validator_spec.rb
+++ b/spec/ubn_validator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe TaiwanValidator::UbnValidator do
       expect(subject.valid?("s" * 8)).to be_falsey
     end
 
-    it "returns true when results % 10 == 0" do
+    it "returns true when results % 5 == 0" do
       expect(subject.valid?("0" * 8)).to be_truthy
     end
 
@@ -40,6 +40,10 @@ RSpec.describe TaiwanValidator::UbnValidator do
       expect(subject.valid?("55667788")).to be_truthy
     end
 
+    it "returns true when ubn is 04595252" do
+      expect(subject.valid?("04595252")).to be_truthy
+    end
+
     it "returns true when ubn is 10458575 and 7th digit is '7'" do
       expect(subject.valid?("10458575")).to be_truthy
     end
@@ -54,6 +58,10 @@ RSpec.describe TaiwanValidator::UbnValidator do
 
     it "returns true when ubn is 00238778 and 7th digit is '7'" do
       expect(subject.valid?("00238778")).to be_truthy
+    end
+
+    it "returns false when ubn is 10458570 and 7th digit is '7'" do
+      expect(subject.valid?("10458570")).to be_truthy
     end
   end
 


### PR DESCRIPTION
The existing pool of UBNs is nearing depletion. To expand the availability of UBNs while maintaining compatibility with the original format, Taiwan’s Ministry of Finance has revised the validation logic for UBNs, effective April 1, 2023.

https://www.fia.gov.tw/singlehtml/3?cntId=c4d9cff38c8642ef8872774ee9987283

The primary change in the validation logic is that UBNs must now be divisible by 5 instead of the previous requirement of divisibility by 10. The updated UBNs are already being incrementally assigned.